### PR TITLE
Accessibility issue fix

### DIFF
--- a/Classes/UVArticleViewController.m
+++ b/Classes/UVArticleViewController.m
@@ -89,6 +89,8 @@
     [self configureView:footer
                subviews:NSDictionaryOfVariableBindings(border, label, yes, no)
             constraints:constraints];
+    
+    footer.accessibilityElements = @[label, yes, no];
 
     [self configureView:self.view
                subviews:NSDictionaryOfVariableBindings(_webView, footer)


### PR DESCRIPTION
The problem is:
While swiping right from the last point, it should announce ‘Was this article helpful’ text first, then it should announce the ‘Yes!’ and ’No’

Issue: But app first announcing the ‘Yes!’ and ‘No’ then it announcing the ‘Was this article helpful?’ text.

Changes: Accessibility elements' order in footer view was set.